### PR TITLE
Added lto for release build.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,6 @@ rand = "0.3"
 lazy_static = "0.2"
 docopt = "0.7"
 rustc-serialize = "0.3"
+
+[profile.release]
+lto = true


### PR DESCRIPTION
This will make release builds smaller by not including unused library functions in build.